### PR TITLE
Add Game Type CLI Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Usage: `java -jar GameController.jar {options}`
     (-l | --league) (spl | spl_mixedteam | spl_penaltyshootout)
                                     select league (default is spl)
     (-w | --window)                 select window mode (default is fullscreen)
+    (-g | --game-type) <game type>  select game type (preliminary or play-off, no default)
 
 
 ### Start Dialog

--- a/src/controller/GameController.java
+++ b/src/controller/GameController.java
@@ -11,6 +11,7 @@ import controller.ui.KeyboardListener;
 import controller.ui.StartInput;
 import data.AdvancedData;
 import data.GameControlData;
+import data.GameType;
 import data.Rules;
 import data.Teams;
 import java.io.File;
@@ -47,6 +48,7 @@ public class GameController {
             + "\n  (-i | --interface) <interface>  set network interface (default is a connected IPv4 interface)"
             + "\n  (-l | --league) %s%sselect league (default is spl)"
             + "\n  (-w | --window)                 select window mode (default is fullscreen)"
+            + "\n  (-g | --game-type) <game type>  select game type (preliminary or play-off, no default)"
             + "\n";
     private static final String COMMAND_INTERFACE = "--interface";
     private static final String COMMAND_INTERFACE_SHORT = "-i";
@@ -54,6 +56,8 @@ public class GameController {
     private static final String COMMAND_LEAGUE_SHORT = "-l";
     private static final String COMMAND_WINDOW = "--window";
     private static final String COMMAND_WINDOW_SHORT = "-w";
+    private static final String COMMAND_GAME_TYPE = "--game-type";
+    private static final String COMMAND_GAME_TYPE_SHORT = "-g";
     private static final String COMMAND_TEST = "--test";
     private static final String COMMAND_TEST_SHORT = "-t";
 
@@ -69,6 +73,7 @@ public class GameController {
         //commands
         String interfaceName = "";
         boolean windowMode = false;
+        GameType gameType = GameType.UNDEFINED;
         boolean testMode = false;
 
         parsing:
@@ -90,6 +95,14 @@ public class GameController {
                 }
             } else if (args[i].equals(COMMAND_WINDOW_SHORT) || args[i].equals(COMMAND_WINDOW)) {
                 windowMode = true;
+                continue parsing;
+            } else if (args[i].equals(COMMAND_GAME_TYPE) || args[i].equals(COMMAND_GAME_TYPE_SHORT)) {
+                i++;
+                if (args[i].equalsIgnoreCase("preliminary")) {
+                    gameType = GameType.PRELIMINARY;
+                } else if (args[i].equalsIgnoreCase("playoff")) {
+                    gameType = GameType.PLAYOFF;
+                }
                 continue parsing;
             } else if (args[i].equals(COMMAND_TEST_SHORT) || args[i].equals(COMMAND_TEST)) {
                 testMode = true;
@@ -200,7 +213,7 @@ public class GameController {
         }
 
         //collect the start parameters and put them into the first data.
-        StartInput input = new StartInput(!windowMode);
+        StartInput input = new StartInput(!windowMode, gameType);
         while (!input.finished) {
             try {
                 Thread.sleep(100);

--- a/src/controller/GameController.java
+++ b/src/controller/GameController.java
@@ -97,11 +97,13 @@ public class GameController {
                 windowMode = true;
                 continue parsing;
             } else if (args[i].equals(COMMAND_GAME_TYPE) || args[i].equals(COMMAND_GAME_TYPE_SHORT)) {
-                i++;
-                if (args[i].equalsIgnoreCase("preliminary")) {
-                    gameType = GameType.PRELIMINARY;
-                } else if (args[i].equalsIgnoreCase("playoff")) {
-                    gameType = GameType.PLAYOFF;
+                if (args.length > i + 1) {
+                    i++;
+                    if (args[i].equalsIgnoreCase("preliminary")) {
+                        gameType = GameType.PRELIMINARY;
+                    } else if (args[i].equalsIgnoreCase("playoff")) {
+                        gameType = GameType.PLAYOFF;
+                    }
                 }
                 continue parsing;
             } else if (args[i].equals(COMMAND_TEST_SHORT) || args[i].equals(COMMAND_TEST)) {

--- a/src/controller/GameController.java
+++ b/src/controller/GameController.java
@@ -96,16 +96,17 @@ public class GameController {
             } else if (args[i].equals(COMMAND_WINDOW_SHORT) || args[i].equals(COMMAND_WINDOW)) {
                 windowMode = true;
                 continue parsing;
-            } else if (args[i].equals(COMMAND_GAME_TYPE) || args[i].equals(COMMAND_GAME_TYPE_SHORT)) {
-                if (args.length > i + 1) {
-                    i++;
-                    if (args[i].equalsIgnoreCase("preliminary")) {
-                        gameType = GameType.PRELIMINARY;
-                    } else if (args[i].equalsIgnoreCase("playoff")) {
-                        gameType = GameType.PLAYOFF;
-                    }
+            } else if ((args.length > i + 1)
+                    && ((args[i].equalsIgnoreCase(COMMAND_GAME_TYPE))
+                    || (args[i].equalsIgnoreCase(COMMAND_GAME_TYPE_SHORT)))) {
+                i++;
+                if (args[i].equalsIgnoreCase("preliminary")) {
+                    gameType = GameType.PRELIMINARY;
+                    continue parsing;
+                } else if (args[i].equalsIgnoreCase("playoff")) {
+                    gameType = GameType.PLAYOFF;
+                    continue parsing;
                 }
-                continue parsing;
             } else if (args[i].equals(COMMAND_TEST_SHORT) || args[i].equals(COMMAND_TEST)) {
                 testMode = true;
                 continue parsing;

--- a/src/controller/GameController.java
+++ b/src/controller/GameController.java
@@ -48,7 +48,7 @@ public class GameController {
             + "\n  (-i | --interface) <interface>  set network interface (default is a connected IPv4 interface)"
             + "\n  (-l | --league) %s%sselect league (default is spl)"
             + "\n  (-w | --window)                 select window mode (default is fullscreen)"
-            + "\n  (-g | --game-type) <game type>  select game type (preliminary or play-off, no default)"
+            + "\n  (-g | --game-type) %s%sselect game type (no default)"
             + "\n";
     private static final String COMMAND_INTERFACE = "--interface";
     private static final String COMMAND_INTERFACE_SHORT = "-i";
@@ -118,8 +118,19 @@ public class GameController {
             if (leagues.contains("|")) {
                 leagues = "(" + leagues + ")";
             }
+            String gameTypes = "";
+            for (GameType gt : GameType.values()) {
+                gameTypes += (gameTypes.equals("") ? "" : " | ") + gt;
+            }
+            if (gameTypes.contains("|")) {
+                gameTypes = "(" + gameTypes + ")";
+            }
+            gameTypes = gameTypes.toLowerCase();
             System.out.printf(HELP_TEMPLATE, leagues, leagues.length() < 17
                     ? "                ".substring(leagues.length())
+                    : "\n                                  ",
+                    gameTypes, gameTypes.length() < 17
+                    ? "                ".substring(gameTypes.length())
                     : "\n                                  ");
             System.exit(0);
         }

--- a/src/controller/ui/StartInput.java
+++ b/src/controller/ui/StartInput.java
@@ -26,6 +26,7 @@ import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 
 import data.GameControlData;
+import data.GameType;
 import data.Rules;
 import data.SPLPenaltyShootout;
 import data.Teams;
@@ -101,7 +102,7 @@ public class StartInput extends JFrame implements Serializable
      * Creates a new StartInput.
      * @param fullscreenMode The preset value of the fullscreen checkbox.
      */
-    public StartInput(boolean fullscreenMode)
+    public StartInput(boolean fullscreenMode, final GameType gameType)
     {
         super(WINDOW_TITLE);
 
@@ -249,6 +250,11 @@ public class StartInput extends JFrame implements Serializable
                     fulltime.setVisible(!(Rules.league instanceof SPLPenaltyShootout));
                     nofulltime.setText(FULLTIME_LABEL_NO);
                     fulltime.setText(FULLTIME_LABEL_YES);
+                    if (gameType == GameType.PRELIMINARY) {
+                        nofulltime.setSelected(true);
+                    } else if (gameType == GameType.PLAYOFF) {
+                        fulltime.setSelected(true);
+                    }
                     autoColorChange.setVisible(false);
                     teamColorChange[0].setVisible(true);
                     teamColorChange[1].setVisible(true);

--- a/src/controller/ui/StartInput.java
+++ b/src/controller/ui/StartInput.java
@@ -33,7 +33,7 @@ import data.Teams;
 
 /**
  * @author Michel Bartsch
- * 
+ *
  * This is only to be on starting the program to get starting input.
  */
 public class StartInput extends JFrame implements Serializable
@@ -63,7 +63,7 @@ public class StartInput extends JFrame implements Serializable
     private static final String COLOR_CHANGE_LABEL = "Auto color change";
     private static final String START_LABEL = "Start";
     private static final String TEAM_COLOR_CHANGE = "Color";
-    
+
     /** If true, this GUI has finished and offers it`s input. */
     public boolean finished = false;
 
@@ -92,7 +92,7 @@ public class StartInput extends JFrame implements Serializable
     private Checkbox fullscreen;
     private Checkbox autoColorChange;
     private JButton start;
-    
+
     private String[][] colorNames = new String[2][];
 
     private HashMap<String, Image> images = new HashMap<String, Image>();
@@ -110,7 +110,7 @@ public class StartInput extends JFrame implements Serializable
         setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         setResizable(false);
         setLayout(new FlowLayout(FlowLayout.CENTER, 0, STANDARD_SPACE));
-        
+
         String[] teams = getShortTeams();
         for (int i=0; i<2; i++) {
             teamContainer[i] = new ImagePanel(getImage(i, i == 0 ? "blue" : "red"));
@@ -213,7 +213,7 @@ public class StartInput extends JFrame implements Serializable
         fullscreen.setPreferredSize(new Dimension(FULLSCREEN_WIDTH, OPTIONS_HEIGHT));
         fullscreen.setState(fullscreenMode);
         fullscreenPanel.add(fullscreen);
-        
+
         autoColorChange = new Checkbox(COLOR_CHANGE_LABEL);
         autoColorChange.setPreferredSize(new Dimension(FULLSCREEN_WIDTH, OPTIONS_HEIGHT));
         autoColorChange.setState(Rules.league.colorChangeAuto);
@@ -290,7 +290,7 @@ public class StartInput extends JFrame implements Serializable
                     outAutoColorChange = autoColorChange.getState();
                     finished = true;
                 }});
-                
+
         league.getActionListeners()[league.getActionListeners().length - 1].actionPerformed(null);
 
         getContentPane().setPreferredSize(new Dimension(WINDOW_WIDTH, WINDOW_HEIGHT));
@@ -298,7 +298,7 @@ public class StartInput extends JFrame implements Serializable
         setVisible(true);
     }
     /** Show in the combo box which teams are available for the selected league and competition*/
-    private void showAvailableTeams() 
+    private void showAvailableTeams()
     {
         outTeam[0] = 0;
         outTeam[1] = 0;
@@ -313,13 +313,13 @@ public class StartInput extends JFrame implements Serializable
             teamIconLabel[i].repaint();
         }
     }
-    
+
     /**
      * Calculates an array that contains only the existing Teams of the
      * current league.
-     * 
+     *
      * @return  Short teams array with numbers
-     */ 
+     */
     private String[] getShortTeams()
     {
         String[] fullTeams = Teams.getNames(true);
@@ -342,13 +342,13 @@ public class StartInput extends JFrame implements Serializable
 
         return out;
     }
-    
+
     /**
      * Sets the Team-Icon on the GUI.
-     * 
+     *
      * @param side      The side (0=left, 1=right)
      * @param team      The number of the Team
-     */ 
+     */
     private void setTeamIcon(int side, int team)
     {
         teamIcon[side] = new ImageIcon(Teams.getIcon(team));
@@ -374,7 +374,7 @@ public class StartInput extends JFrame implements Serializable
                 (int)(teamIcon[side].getImage().getHeight(null)*scaleFactor),
                 Image.SCALE_SMOOTH));
     }
-    
+
     /**
      * Enables the start button, if the conditions are ok.
      */
@@ -383,7 +383,7 @@ public class StartInput extends JFrame implements Serializable
         start.setEnabled(outTeam[0] != outTeam[1] &&
                 (fulltime.isSelected() || nofulltime.isSelected() || !fulltime.isVisible()));
     }
-    
+
     private Image getImage(int side, String color)
     {
         String filename = Rules.league.leagueName + "/" + side + "/" + color;
@@ -391,7 +391,7 @@ public class StartInput extends JFrame implements Serializable
 
             // Default color when color is not available in Rules.league.teamColor:
             Color c = Color.WHITE;
-            
+
             // Search the Java.awt.Color-Class for Color-Name:
             for(int i=0; i<Rules.league.teamColorName.length; i++){
                 if(Rules.league.teamColorName[i].toLowerCase().equals(color.toLowerCase())){
@@ -399,7 +399,7 @@ public class StartInput extends JFrame implements Serializable
                     break;
                 }
             }
-            
+
             Image image = new BackgroundImage(ICONS_PATH + Rules.league.leagueDirectory + BACKGROUND_EXT, side==1, c).getImage();
             images.put(filename, image);
         }
@@ -477,39 +477,39 @@ public class StartInput extends JFrame implements Serializable
 
     /**
      * @author Michel Bartsch
-     * 
+     *
      * This is a normal JPanel, but it has a background image.
      */
     class ImagePanel extends JPanel
     {
         private static final long serialVersionUID = 1L;
-        
+
         /** The image that is shown in the background. */
         private Image image;
 
         /**
          * Creates a new ImagePanel.
-         * 
+         *
          * @param image     The Image to be shown in the background.
          */
         public ImagePanel(Image image)
         {
             this.image = image;
         }
-        
+
         /**
          * Changes the background image.
-         * 
+         *
          * @param image     Changes the image to this one.
          */
         public void setImage(Image image)
         {
             this.image = image;
         }
-        
+
         /**
          * Paints this Component, should be called automatically.
-         * 
+         *
          * @param g     This components graphical content.
          */
         @Override

--- a/src/controller/ui/StartInput.java
+++ b/src/controller/ui/StartInput.java
@@ -101,6 +101,7 @@ public class StartInput extends JFrame implements Serializable
     /**
      * Creates a new StartInput.
      * @param fullscreenMode The preset value of the fullscreen checkbox.
+     * @param gameType The game type (either UNDEFINED, PRELIMINARY or PLAYOFF)
      */
     public StartInput(boolean fullscreenMode, final GameType gameType)
     {

--- a/src/data/GameType.java
+++ b/src/data/GameType.java
@@ -1,0 +1,6 @@
+package data;
+
+public enum GameType
+{
+    UNDEFINED, PRELIMINARY, PLAYOFF;
+}


### PR DESCRIPTION
This PR adds the command line option `--game-type`. The game type can be set to preliminary or play-off. It defaults to no selection. I also removed some whitespaces.